### PR TITLE
Update HPKP

### DIFF
--- a/windows-media/isos/download-windows.sh
+++ b/windows-media/isos/download-windows.sh
@@ -85,7 +85,7 @@ done
 trap exit ERR
 
 download_microsoft_com_key="sha256//C1Ivsf0VYDC6TILfQWXF0j71jAsAesFVXGgyzSvjqvo="
-software_download_microsoft_com_key="sha256//XkxB3HpkW1URRks+KuhFNxVJTbtJeWIvl1KzpWrplcM="
+software_download_microsoft_com_key="sha256//rnXgdWLOejNRPNbtt0e9bPOrVh4mIrnJ9AjE3Fb3UAY="
 
 scurl_file() {
     out_file="$1"

--- a/windows-media/isos/download-windows.sh
+++ b/windows-media/isos/download-windows.sh
@@ -84,7 +84,7 @@ done
 
 trap exit ERR
 
-download_microsoft_com_key="sha256//2e0F/Ardt/GQmXeDy1wheisQhjSImsJtf1rIekoQE7E="
+download_microsoft_com_key="sha256//C1Ivsf0VYDC6TILfQWXF0j71jAsAesFVXGgyzSvjqvo="
 software_download_microsoft_com_key="sha256//XkxB3HpkW1URRks+KuhFNxVJTbtJeWIvl1KzpWrplcM="
 
 scurl_file() {


### PR DESCRIPTION
It is necessary to update the HPKP for 'download.microsoft.com' and 'software-download.microsoft.com'.

I have used the script down below to obtain the HPKP in a reasonably secure fashion through the Tor network. Please raise your concerns if you have gotten a different result.

<details><summary>get_pubkey.sh</summary>
<p>

```bash
#/usr/bin/bash
# This script fetches the HPKP for the given host multiple times through Tor.
# It is meant to be run in a Whonix Workstation Qube.

SERVER="download.microsoft.com"
ITERATIONS=10

fetch_pubkey() {
	local pubkey=$(echo "QUIT" | torify openssl s_client -servername ${SERVER} -connect ${SERVER}:443 -tls1_2 | openssl x509 -pubkey -noout | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64) 
	echo $pubkey
}

sleep_randomly() {
	local time=$(python3 -c 'import secrets; print(secrets.SystemRandom().uniform(0.0, 1200.0))')
	sleep ${time}
	echo "Sleeping for ${time} seconds."
}

compare() {
	local pubkey=$(fetch_pubkey)
	for ((i = 0 ; i < ${ITERATIONS} ; i++)); do
  		if [[ ${pubkey} != $(fetch_pubkey) ]]; then
  			echo "I have received different public keys." 
  			exit 1
  		fi
  		sleep_randomly
	done
	echo "The public key for ${SERVER} is '${pubkey}'. I have checked it ${ITERATIONS} times."
}

compare
```

</p>
</details>
