### PR TITLE
REMOVE - munged when branch was renamed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,12 +51,11 @@ if [ "$netvm" ]; then
 fi
 
 # Validate QWT iso
-if [ -e "/usr/lib/qubes/qubes-windows-tools.iso" ]
-    then
-        echo -e "${BLUE}[i]${NC} Verified that Qubes Windows Tools is already installed in dom0, skipping download..." >&2
-    else
-        echo -e "${BLUE}[i]${NC} Installing Qubes Windows Tools..." >&2
-        sudo qubes-dom0-update -y qubes-windows-tools || (echo "${RED}[i]${NC} Error downloading Qubes Windows Tools, exiting..." && exit 1)
+if [ -e "/usr/lib/qubes/qubes-windows-tools.iso" ]; then
+    echo -e "${BLUE}[i]${NC} Verified that Qubes Windows Tools is already installed in dom0, skipping download..." >&2
+else
+    echo -e "${BLUE}[i]${NC} Installing Qubes Windows Tools..." >&2
+    sudo qubes-dom0-update -y qubes-windows-tools || (echo "${RED}[i]${NC} Error downloading Qubes Windows Tools, exiting..." && exit 1)
 fi
 
 resources_qube="windows-mgmt"


### PR DESCRIPTION
This will skip download of QWT when present and will also explain why the script is terminating if download fails.

In addition, the download of QWT is performed earlier in the script, so that the script exits cleanly before a management VM is partially created, should QWT not be available.

Updated: two commits added to fix boolean logic grouping in exit path and missing semicolon.