### PR TITLE
Skip qubes-windows-tools.iso download and installation if already present.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ if [ -e "/usr/lib/qubes/qubes-windows-tools.iso" ]; then
     echo -e "${BLUE}[i]${NC} Verified that Qubes Windows Tools is already installed in dom0, skipping download..." >&2
 else
     echo -e "${BLUE}[i]${NC} Installing Qubes Windows Tools..." >&2
-    sudo qubes-dom0-update -y qubes-windows-tools || (echo "${RED}[i]${NC} Error downloading Qubes Windows Tools, exiting..." && exit 1)
+    sudo qubes-dom0-update -y qubes-windows-tools || (echo -e "${RED}[i]${NC} Error downloading Qubes Windows Tools, exiting..." && exit 1)
 fi
 
 resources_qube="windows-mgmt"

--- a/install.sh
+++ b/install.sh
@@ -56,11 +56,11 @@ if [ -f "/usr/lib/qubes/qubes-windows-tools.iso" ]; then
 else
     echo -e "${BLUE}[i]${NC} Installing Qubes Windows Tools..." >&2
     if ! sudo qubes-dom0-update -y qubes-windows-tools; then
-        echo -e "${RED}[!]${NC} Error installing Qubes Windows Tools! Exiting..."
+        echo -e "${RED}[!]${NC} Error installing Qubes Windows Tools! Exiting..." >&2
         exit 1
     fi
     if ! [ -f "/usr/lib/qubes/qubes-windows-tools.iso" ]; then
-        echo -e "${RED}[!]${NC} Qubes Windows Tools package is installed, but /usr/lib/qubes/qubes-windows-tools.iso is still missing in Dom0. Exiting..."
+        echo -e "${RED}[!]${NC} Qubes Windows Tools package is installed, but /usr/lib/qubes/qubes-windows-tools.iso is still missing in Dom0. Exiting..." >&2
         exit 1
     fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -50,14 +50,18 @@ if [ "$netvm" ]; then
     fi
 fi
 
-# Validate QWT iso
-if [ -e "/usr/lib/qubes/qubes-windows-tools.iso" ]; then
-    echo -e "${BLUE}[i]${NC} Verified that Qubes Windows Tools is already installed in dom0, skipping download..." >&2
+# Validate QWT installation
+if [ -f "/usr/lib/qubes/qubes-windows-tools.iso" ]; then
+    echo -e "${BLUE}[i]${NC} Qubes Windows Tools is already installed in Dom0. Skipping download..." >&2
 else
     echo -e "${BLUE}[i]${NC} Installing Qubes Windows Tools..." >&2
-    sudo qubes-dom0-update -y qubes-windows-tools || (echo -e "${RED}[i]${NC} Error installing Qubes Windows Tools, exiting..." && exit 1)
-    if [ ! -e "/usr/lib/qubes/qubes-windows-tools.iso" ]; then
-        echo -e "${RED}[i]${NC} Qubes Windows Tools RPM was installed, but /usr/lib/qubes/qubes-windows-tools.iso is still missing. Exiting..." && exit 1
+    if ! sudo qubes-dom0-update -y qubes-windows-tools; then
+        echo -e "${RED}[!]${NC} Error installing Qubes Windows Tools! Exiting..."
+        exit 1
+    fi
+    if ! [ -f "/usr/lib/qubes/qubes-windows-tools.iso" ]; then
+        echo -e "${RED}[!]${NC} Qubes Windows Tools package was installed, but /usr/lib/qubes/qubes-windows-tools.iso is still missing in Dom0. Exiting..."
+        exit 1
     fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,10 @@ if [ -e "/usr/lib/qubes/qubes-windows-tools.iso" ]; then
     echo -e "${BLUE}[i]${NC} Verified that Qubes Windows Tools is already installed in dom0, skipping download..." >&2
 else
     echo -e "${BLUE}[i]${NC} Installing Qubes Windows Tools..." >&2
-    sudo qubes-dom0-update -y qubes-windows-tools || (echo -e "${RED}[i]${NC} Error downloading Qubes Windows Tools, exiting..." && exit 1)
+    sudo qubes-dom0-update -y qubes-windows-tools || (echo -e "${RED}[i]${NC} Error installing Qubes Windows Tools, exiting..." && exit 1)
+    if [ ! -e "/usr/lib/qubes/qubes-windows-tools.iso" ]; then
+        echo -e "${RED}[i]${NC} Qubes Windows Tools RPM was installed, but /usr/lib/qubes/qubes-windows-tools.iso is still missing. Exiting..." && exit 1
+    fi
 fi
 
 resources_qube="windows-mgmt"

--- a/install.sh
+++ b/install.sh
@@ -51,12 +51,11 @@ if [ "$netvm" ]; then
 fi
 
 # Validate QWT iso
-if [ -e "/usr/lib/qubes/qubes-windows-tools.iso" ]
-    then
-        echo -e "${BLUE}[i]${NC} Verified that Qubes Windows Tools is already installed in dom0, skipping download..." >&2
-    else
-        echo -e "${BLUE}[i]${NC} Installing Qubes Windows Tools..." >&2
-        sudo qubes-dom0-update -y qubes-windows-tools || (echo "${RED}[i]${NC} Error downloading Qubes Windows Tools, exiting..." && exit 1)
+if [ -e "/usr/lib/qubes/qubes-windows-tools.iso" ]; then
+    echo -e "${BLUE}[i]${NC} Verified that Qubes Windows Tools is already installed in dom0, skipping download..." >&2
+else
+    echo -e "${BLUE}[i]${NC} Installing Qubes Windows Tools..." >&2
+    sudo qubes-dom0-update -y qubes-windows-tools || (echo "${RED}[i]${NC} Error downloading Qubes Windows Tools, exiting..." && exit 1)
 fi
 
 resources_qube="windows-mgmt"

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ if [ -e "/usr/lib/qubes/qubes-windows-tools.iso" ]
         echo -e "${BLUE}[i]${NC} Verified that Qubes Windows Tools is already installed in dom0, skipping download..." >&2
     else
         echo -e "${BLUE}[i]${NC} Installing Qubes Windows Tools..." >&2
-        sudo qubes-dom0-update -y qubes-windows-tools || echo "${RED}[i]${NC} Error downloading Qubes Windows Tools, exiting..." && exit 1
+        sudo qubes-dom0-update -y qubes-windows-tools || (echo "${RED}[i]${NC} Error downloading Qubes Windows Tools, exiting..." && exit 1)
 fi
 
 resources_qube="windows-mgmt"

--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,7 @@ else
         exit 1
     fi
     if ! [ -f "/usr/lib/qubes/qubes-windows-tools.iso" ]; then
-        echo -e "${RED}[!]${NC} Qubes Windows Tools package was installed, but /usr/lib/qubes/qubes-windows-tools.iso is still missing in Dom0. Exiting..."
+        echo -e "${RED}[!]${NC} Qubes Windows Tools package is installed, but /usr/lib/qubes/qubes-windows-tools.iso is still missing in Dom0. Exiting..."
         exit 1
     fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,15 @@ if [ "$netvm" ]; then
     fi
 fi
 
+# Validate QWT iso
+if [ -e "/usr/lib/qubes/qubes-windows-tools.iso" ]
+    then
+        echo -e "${BLUE}[i]${NC} Verified that Qubes Windows Tools is already installed in dom0, skipping download..." >&2
+    else
+        echo -e "${BLUE}[i]${NC} Installing Qubes Windows Tools..." >&2
+        sudo qubes-dom0-update -y qubes-windows-tools || echo "${RED}[i]${NC} Error downloading Qubes Windows Tools, exiting..." && exit 1
+fi
+
 resources_qube="windows-mgmt"
 resources_dir="/home/user/Documents/qvm-create-windows-qube"
 template="$(qubes-prefs default_template)"
@@ -107,9 +116,6 @@ qvm-shutdown --wait "$resources_qube"
 
 echo -e "${BLUE}[i]${NC} Air gapping $resources_qube..." >&2
 qvm-prefs "$resources_qube" netvm ""
-
-echo -e "${BLUE}[i]${NC} Installing Qubes Windows Tools..." >&2
-sudo qubes-dom0-update -y qubes-windows-tools
 
 echo -e "${BLUE}[i]${NC} Copying qvm-create-windows-qube main program to Dom0..." >&2
 qvm-run -p --filter-escape-chars --no-color-output "$resources_qube" "cat '$resources_dir/qvm-create-windows-qube'" | sudo tee /usr/bin/qvm-create-windows-qube > /dev/null


### PR DESCRIPTION
This will:
  - Skip download of qubes-windows-tools.iso when already present in /usr/lib/qubes/ which will allow the script to run faster in most circumstances, esp. if user gets dom0 updates via sys-whonix.
  - Explain why the script is terminating if qubes-windows-tools installation fails or iso file is missing after installation.

In addition, as the qvm-create-windows-qube script has a hard dependency on QWT, the installation of qubes-windows-tools.iso is now performed much earlier in the script. This ensures, when the iso is not currently available, that the script exits cleanly *before* an incomplete management VM is created.

Tested in various configurations with R4.0 (with and without rpm-installed official ISO) and R4.1 (with and without manually-installed tabit-pro ISO).

Brendan

