### PR TITLE
Wait for reboot prompt before final shutdown

### DIFF
--- a/qvm-create-windows-qube
+++ b/qvm-create-windows-qube
@@ -464,6 +464,9 @@ for (( counter = 1; counter <= count; counter++ )); do
         sudo rm -f "$policy_file"
     fi
 
+    # Wait for xenvif reboot prompt, otherwise it might happen after reboot
+    qvm-run -q "$qube" "start /wait wscript e:\\wait-for-reboot-prompt.vbs" || true
+
     echo_info "Shutting down Windows..."
     # Shutdown and wait until complete before finishing or starting next installation
     qvm-shutdown --wait "$qube"

--- a/tools/auto-qwt/install-qwt.bat
+++ b/tools/auto-qwt/install-qwt.bat
@@ -4,6 +4,10 @@ title %~f0
 :: Copyright (C) 2023 Elliot Killick <contact@elliotkillick.com>
 :: Licensed under the MIT License. See LICENSE file for details.
 
+:: DEBUG
+
+reg add "HKLM\Software\Invisible Things Lab\Qubes Tools" /v "LogLevel" /t REG_DWORD /d 5
+
 cd installer || exit
 for %%i in (qubes-tools-*.exe qubes-tools-*.msi) do (
     start %%i /passive

--- a/tools/auto-qwt/wait-for-reboot-prompt.vbs
+++ b/tools/auto-qwt/wait-for-reboot-prompt.vbs
@@ -1,0 +1,25 @@
+' Confirm reboot after xenvif driver installation, based on allow-drivers.vbs
+' This is called by qvm-create-windows-qube directly, after QWT gets detected by dom0
+
+Set wshShell = WScript.CreateObject("WScript.Shell")
+timeout = 60
+
+Do
+    ' Set focus to window with given window title
+    isFocused = wshShell.AppActivate("Xen", 0)
+
+    ' If focus is successful
+    If isFocused = True Then
+        ' WScript.Echo "Found 'Xen' prompt, confirming it"
+        ' Press "i" (ALT key) to install device software
+        wshShell.SendKeys "{ENTER}"
+        Exit Do
+    End If
+
+    WScript.Sleep 1000
+    timeout = timeout - 1
+    If timeout <= 0 Then
+        'WScript.Echo "Timeout waiting for 'Xen' prompt"
+        Exit Do
+    End If
+Loop


### PR DESCRIPTION
If VM is shutdown before the prompt, it may happen at the next start,
possibly interrupting user interaction.

Note if VM is started without netvm and then with netvm again the prompt
will be there anyway.